### PR TITLE
`setup.py` added, so that we can use expman with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from distutils.core import setup
+
+setup(
+    name='ExpMan',
+    version='0.1',
+    packages=['expman']
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 from distutils.core import setup
 
 setup(
-    name='ExpMan',
+    name='expman',
+    description='a simple experiment manager and organizer',
     version='0.1',
+    url='https://github.com/fabiocarrara/expman',
+    author='Fabio Carrara',
+    author_email='fabio.carrara@isti.cnr.it',
     packages=['expman']
 )


### PR DESCRIPTION
This adds a basic`setup.py`, so that anyone can use `pip install <repo url>` to install and use expman.

Let me know if you want any additional or different info in the proposed change. 